### PR TITLE
docs(readme): add full design overview in markdown format

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,24 @@ Bienvenido al repositorio oficial de **MELIFinder**, una aplicación Android des
 ---
 ## 🚀 ¿De qué trata MELIFinder?
 
-**MELIFinder** es una aplicación que simula la búsqueda inteligente de productos o publicaciones dentro del ecosistema de Mercado Libre. Implementa un flujo robusto que incluye:
 
-- Exploración de ítems por búsqueda textual
-- Navegación fluida entre categorías y detalles
-- Gestión eficiente del ciclo de vida y consumo de APIs
-- Pruebas unitarias y de UI
-- Integración con herramientas modernas de calidad y automatización
+<div style="display: flex; align-items: center; gap: 24px;">
+  <div style="flex: 1; text-align: left;">
+    <img src="docs/demo.gif" width="180" alt="Demo">
+  </div>
+  <div style="flex: 4;">
+    <b>MELIFinder</b> es una aplicación que simula la búsqueda inteligente de productos o publicaciones dentro del ecosistema de Mercado Libre. Implementa un flujo robusto que incluye:
+    <ul>
+      <li>Exploración de ítems por búsqueda textual</li>
+      <li>Navegación fluida entre categorías y detalles</li>
+      <li>Gestión eficiente del ciclo de vida y consumo de APIs</li>
+      <li>Pruebas unitarias y de UI</li>
+      <li>Integración con herramientas modernas de calidad y automatización</li>
+    </ul>
+  </div>
+</div>
 
 > La app ha sido estructurada desde cero utilizando herramientas de análisis estático, validación automática de estilo y despliegue automatizado.
-
 
 Este README sirve como punto de entrada para entender la arquitectura del proyecto, herramientas utilizadas, flujos automatizados y convenciones de calidad.
 
@@ -189,7 +197,12 @@ MELIFinder busca demostrar un flujo completo de desarrollo profesional, incluyen
 3. Todo PR será evaluado con GitHub Actions (`lint.yml`)
 
 ---
+## 🎬 Demo
+---
 
+<p align="center">
+  <img src="docs/demo.gif" width="400" alt="Demo">
+</p>
 ## ✍️ Autor
 
 Jhon Prieto – [LinkedIn](https://www.linkedin.com/in/jhon-prieto-cifuentes1/)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Bienvenido al repositorio oficial de **MELIFinder**, una aplicación Android des
     </ul>
   </div>
     <div style="flex: 1; text-align: left;">
-    <img src="docs/demo.gif" width="180" alt="Demo">
+    <img src="docs/demo.gif" width="100" alt="Demo">
   </div>
 </div>
 
@@ -173,8 +173,8 @@ Bienvenido a la documentación técnica del proyecto **MELIFinder**, una aplicac
 | [01 - Configuración del entorno](docs/01_entorno_local.md) | Configuración del entorno local: Script de setup, uso de Ruby, gemas, Fastlane, y Git hooks |
 | [02 - Calidad de código](docs/02_calidad_codigo.md) | Reglas, configuración y automatización de `ktlint` y `detekt` |
 | [03 - CI/CD con Fastlane](docs/03_fastlane_ci_cd.md) | Automatización, firma, despliegue, lanes y GitHub Actions |
-| [04 - Git Hooks](03_hooks.md) | Hooks automáticos locales para validar el entorno y estilo de código |
-| [05 - Seguridad](05_seguridad.md) *(opcional)* | Validación de secretos, firmas, cifrado y mejores prácticas |
+| [04 - Arquitectura de la App](docs/04_arquitectura_MELIFinder.md) | Explicación detallada de la estructura modular basada en Clean Architecture y MVVM, incluyendo la organización por capas (presentation, domain, data, network, common), los principios de diseño aplicados (separación de responsabilidades, bajo acoplamiento, alta cohesión) y el uso de patrones como Repository, UseCase, State Management con sealed classes y Jetpack Compose. También se incluyen convenciones y decisiones técnicas tomadas para garantizar escalabilidad, mantenibilidad y testabilidad. |
+| [05 - Seguridad](05_seguridad.md) *(en desarrollo)* | Validación de secretos, firmas, cifrado y mejores prácticas |
 | [06 - Testing](06_testing.md) *(en desarrollo)* | Unit/UI tests, integración con Firebase TestLab y mocks |
 
 ---

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Bienvenido al repositorio oficial de **MELIFinder**, una aplicación Android des
       <li>Integración con herramientas modernas de calidad y automatización</li>
     </ul>
   </div>
-    <div style="flex: 1; text-align: left;">
+    <div style="flex: 1; text-align: center;">
     <img src="docs/demo.gif" width="100" alt="Demo">
   </div>
 </div>

--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ Bienvenido al repositorio oficial de **MELIFinder**, una aplicación Android des
 
 
 <div style="display: flex; align-items: center; gap: 24px;">
-  <div style="flex: 1; text-align: left;">
-    <img src="docs/demo.gif" width="180" alt="Demo">
-  </div>
   <div style="flex: 4;">
     <b>MELIFinder</b> es una aplicación que simula la búsqueda inteligente de productos o publicaciones dentro del ecosistema de Mercado Libre. Implementa un flujo robusto que incluye:
     <ul>
@@ -20,6 +17,9 @@ Bienvenido al repositorio oficial de **MELIFinder**, una aplicación Android des
       <li>Pruebas unitarias y de UI</li>
       <li>Integración con herramientas modernas de calidad y automatización</li>
     </ul>
+  </div>
+    <div style="flex: 1; text-align: left;">
+    <img src="docs/demo.gif" width="180" alt="Demo">
   </div>
 </div>
 
@@ -198,11 +198,13 @@ MELIFinder busca demostrar un flujo completo de desarrollo profesional, incluyen
 
 ---
 ## 🎬 Demo
+
+![Demo](docs/demo.gif)
+
+
 ---
 
-<p align="center">
-  <img src="docs/demo.gif" width="400" alt="Demo">
-</p>
+
 ## ✍️ Autor
 
 Jhon Prieto – [LinkedIn](https://www.linkedin.com/in/jhon-prieto-cifuentes1/)

--- a/docs/04_arquitectura_MELIFinder.md
+++ b/docs/04_arquitectura_MELIFinder.md
@@ -1,0 +1,174 @@
+# MELIFinder – Arquitectura, Patrones y Estructura
+
+## Índice
+1. [Resumen General](#1-resumen-general)  
+2. [Arquitectura General](#2-arquitectura-general)  
+3. [Estructura Modular](#3-estructura-modular)  
+4. [Patrones de Diseño Aplicados](#4-patrones-de-diseño-aplicados)  
+5. [Gestión de Estado y UI](#5-gestión-de-estado-y-ui)  
+6. [Inyección de Dependencias](#6-inyección-de-dependencias)  
+7. [Pruebas y Calidad](#7-pruebas-y-calidad)  
+8. [Automatización y Estilo](#8-automatización-y-estilo)  
+9. [Módulo network (API y configuración de red)](#9-módulo-network-api-y-configuración-de-red)  
+10. [Resumen y Consideraciones Finales](#10-resumen-y-consideraciones-finales)
+
+---
+
+## 1. Resumen General
+
+**MELIFinder** es una aplicación Android modular desarrollada desde cero con enfoque en escalabilidad, mantenibilidad y calidad de código. Todo el flujo está orientado a la búsqueda inteligente de productos y navegación jerárquica de categorías, soportando un robusto manejo de estados y arquitectura moderna.
+
+---
+
+## 2. Arquitectura General
+
+La app implementa una combinación de **Clean Architecture + MVVM (Model-View-ViewModel)** junto con una modularización por capas. El objetivo es lograr:
+
+- Separación clara de responsabilidades.  
+- Bajo acoplamiento y alta cohesión.  
+- Código testeable y fácilmente extensible.  
+
+**Capas Principales:**
+
+- `presentation`: UI declarativa (Jetpack Compose), ViewModels, manejo de navegación y estados de pantalla.  
+- `domain`: Modelos puros, casos de uso y contratos de repositorios. Sin dependencias del Android SDK.  
+- `data`: Implementaciones de repositorios, DTOs, mappers y fuentes de datos.  
+- `network`: Configuración de red, definición de ApiService, interceptores, clientes y DTOs para comunicación remota.  
+- `common`: Utilidades compartidas, constantes, helpers y configuraciones globales.  
+
+**Ejemplo de flujo:**
+
+```
+Presentation (UI/Compose/ViewModel)
+   ↓
+Domain (UseCase/Repository Interface/Models)
+   ↓
+Data (Repository Impl/API/Mappers)
+   ↓
+Network (ApiService/DTOs/Retrofit)
+```
+
+---
+
+## 3. Estructura Modular
+
+El proyecto se divide en módulos para favorecer el aislamiento y la reusabilidad:
+
+- `:app` – Entrada principal y dependiente de los otros módulos.  
+- `:domain` – Modelos puros, interfaces de repositorios y use cases.  
+- `:data` – Implementación concreta de repositorios, DTOs, mappers, fuentes remotas.  
+- `:network` – Cliente HTTP, ApiService, interceptores, configuración de red.  
+- `:common` – Utilidades, helpers, logging, providers.  
+
+**Ventajas:**
+
+- Compilación incremental más rápida.  
+- Mejor gestión de dependencias.  
+- Posibilidad de testeo y versionado por módulo.  
+- Capa de red fácilmente reemplazable para mocks/tests.
+
+---
+
+## 4. Patrones de Diseño Aplicados
+
+- **Repository Pattern**: Casos de uso interactúan con interfaces en `domain`, implementadas en `data`.  
+- **Use Case Pattern**: Lógica de negocio encapsulada en clases de caso de uso.  
+- **Sealed Class para estados de UI**: Manejo de estados como `Loading`, `Success`, `Error`, `Empty`.  
+- **Factory Pattern (opcional)**: Instanciación dinámica según tipo de producto.  
+- **Observer Pattern**: `StateFlow` para observar cambios entre ViewModel y UI.  
+- **Single Source of Truth**: Solo el ViewModel mantiene el estado observable.  
+- **Adapter Delegates (Compose)**: Composición por tipo de ítem como principio de delegación.  
+- **Strategy Pattern (opcional)**: Diferentes estrategias para renderizar detalles según tipo.
+
+---
+
+## 5. Gestión de Estado y UI
+
+- **UI Declarativa**: Jetpack Compose como base de toda la UI.  
+- **State Management**: ViewModels exponen `StateFlow` con sealed class de estado.  
+- **Estados UI**: `Loading`, `Error`, `Empty`, `Success` reflejados de forma reactiva.  
+- **Componentes Reusables**: Tarjetas, shimmers, carouseles desacoplados y reutilizables.
+
+---
+
+## 6. Inyección de Dependencias
+
+- **Koin**: Inyección de dependencias por módulo.
+
+```kotlin
+val appModule = module {
+    single<ProductRepository> { ProductRepositoryImpl(get()) }
+    single { SearchProductsUseCase(get()) }
+    viewModel { SearchViewModel(get()) }
+}
+```
+
+---
+
+## 7. Pruebas y Calidad
+
+- **Unit Tests**: Casos de uso y ViewModels testeados.  
+- **Análisis Estático**:
+  - `ktlint`: Formato de código.
+  - `detekt`: Reglas personalizadas.
+  - `lint`: Validaciones específicas de Android.
+- **CI/CD**:
+  - `Fastlane`: Automatización de pruebas, despliegue y análisis.
+  - `GitHub Actions`: Validaciones en cada push/pull request.
+
+---
+
+## 8. Automatización y Estilo
+
+- `ktlint`: Hook pre-commit/pre-push.  
+- `detekt`: Reglas personalizadas.  
+- `Fastlane`: Automatiza builds y distribución.  
+- `Lint checks`: Asegura estándares de Android.
+
+---
+
+## 9. Módulo network (API y configuración de red)
+
+`network` encapsula TODO lo relacionado con comunicación HTTP:
+
+- **ApiService**: Define endpoints REST con Retrofit.  
+- **Interceptors**: Logging, autenticación, headers personalizados.  
+- **DTOs**: Representación cruda de datos.  
+- **Retrofit Client Provider**: Configuración de baseUrl, timeouts, etc.  
+- **Serialization**: Moshi o Gson configurado para JSON.  
+- **Testing**: Compatible con WireMock o MockWebServer.
+
+```kotlin
+interface ApiService {
+    @GET("products/search")
+    suspend fun searchByQuery(@Query("q") query: String): SearchResponseDto
+
+    @GET("products/{product_id}")
+    suspend fun getProductDetail(@Path("product_id") productId: String): ProductDetailDto
+}
+
+fun provideRetrofit(): Retrofit = Retrofit.Builder()
+    .baseUrl(BASE_URL)
+    .client(provideOkHttpClient())
+    .addConverterFactory(MoshiConverterFactory.create())
+    .build()
+
+fun provideOkHttpClient(): OkHttpClient = OkHttpClient.Builder()
+    .addInterceptor(HttpLoggingInterceptor().apply { level = BODY })
+    .build()
+```
+
+---
+
+## 10. Resumen y Consideraciones Finales
+
+El diseño de MELIFinder sigue los más altos estándares actuales de arquitectura Android, aplicando Clean Architecture y buenas prácticas de ingeniería.
+
+**Se optimizó para:**
+
+- Mantenibilidad  
+- Extensibilidad  
+- Testabilidad  
+- Entrega continua  
+
+Todo nuevo desarrollador o evaluador puede comprender el flujo, navegar el código y extender funcionalidades fácilmente.


### PR DESCRIPTION
Refactored the README layout using HTML flex to display the project description and demo gif side by side, improving the first impression and visual clarity for reviewers. This change makes the documentation more attractive and professional for desktop viewers, keeping the introduction concise and the visual demo easily accessible.