### PR TITLE
refactor(repository): unify error handling for getCategories with ApiResult

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/src/main/java/com/jhonprieto/melifinder/ui/screens/category/CategoriesSection.kt
+++ b/app/src/main/java/com/jhonprieto/melifinder/ui/screens/category/CategoriesSection.kt
@@ -8,7 +8,6 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -43,6 +42,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.jhonprieto.domain.model.Category
+import com.jhonprieto.melifinder.ui.screens.search.searchErrorView
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -54,14 +54,16 @@ fun categoriesSection(
 
     LaunchedEffect(Unit) { viewModel.loadCategories() }
 
-    when (uiState) {
+    when (val state = uiState) {
         is CategoryUiState.Loading -> homeLoadingGrid()
-        is CategoryUiState.Error -> homeErrorView((uiState as CategoryUiState.Error).message)
+        is CategoryUiState.Error -> searchErrorView(
+            errorType = state.type,
+            onRetry = { viewModel.loadCategories() }
+        )
         is CategoryUiState.Success -> homeCategoryGrid((uiState as CategoryUiState.Success).categories, onCategoryClick)
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun homeCategoryGrid(categories: List<Category>, onCategoryClick: (Category) -> Unit) {
     LazyVerticalGrid(

--- a/app/src/main/java/com/jhonprieto/melifinder/ui/screens/category/CategoryViewModel.kt
+++ b/app/src/main/java/com/jhonprieto/melifinder/ui/screens/category/CategoryViewModel.kt
@@ -2,6 +2,8 @@ package com.jhonprieto.melifinder.ui.screens.category
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.jhonprieto.domain.ApiResult
+import com.jhonprieto.domain.error.ApiErrorType
 import com.jhonprieto.domain.model.Category
 import com.jhonprieto.domain.usecases.GetCategoriesUseCase
 import com.jhonprieto.domain.usecases.GetCategoryDetailUseCase
@@ -9,12 +11,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.io.IOException
 
 sealed class CategoryUiState {
     object Loading : CategoryUiState()
     data class Success(val categories: List<Category>) : CategoryUiState()
-    data class Error(val message: String) : CategoryUiState()
+    data class Error(val type: ApiErrorType, val message: String) : CategoryUiState()
 }
 
 class CategoryViewModel(
@@ -23,47 +24,55 @@ class CategoryViewModel(
 ) : ViewModel() {
 
     private val _categories = MutableStateFlow<List<Category>>(emptyList())
-    val categories: StateFlow<List<Category>> = _categories
-
     private val _uiState = MutableStateFlow<CategoryUiState>(CategoryUiState.Loading)
     val uiState: StateFlow<CategoryUiState> = _uiState
-
-    private val _loading = MutableStateFlow(true)
-    val loading: StateFlow<Boolean> = _loading
-
-    private val _error = MutableStateFlow<String?>(null)
-    val error: StateFlow<String?> = _error
 
     private val pictureCache = mutableMapOf<String, String?>()
 
     fun loadCategories() {
+        _uiState.value = CategoryUiState.Loading
         viewModelScope.launch {
-            _loading.value = true
-            _error.value = null
-            try {
-                val cats = getCategoriesUseCase()
-                _categories.value = cats
+            when (val result = getCategoriesUseCase()) {
+                is ApiResult.Success -> {
+                    val categories = result.data
+                    if (categories.isEmpty()) {
+                        _uiState.value = CategoryUiState.Success(emptyList())
+                        return@launch
+                    }
 
-                cats.forEach { category ->
-                    if (pictureCache[category.id] == null) {
-                        launch {
-                            val detail = getCategoryDetailUseCase(category.id)
-                            pictureCache[category.id] = detail.pictureUrl
-                            _categories.update { list ->
-                                list.map {
-                                    if (it.id == category.id) it.copy(picture = detail.pictureUrl) else it
+                    _uiState.value = CategoryUiState.Success(categories)
+
+                    categories.forEach { category ->
+                        if (pictureCache[category.id] == null) {
+                            launch {
+                                val detail = getCategoryDetailUseCase(category.id)
+                                pictureCache[category.id] = detail.pictureUrl
+                                _categories.update { list ->
+                                    list.map {
+                                        if (it.id == category.id) it.copy(picture = detail.pictureUrl) else it
+                                    }
                                 }
+                                // *** Aquí fuerza también el UI State ***
+                                _uiState.value = CategoryUiState.Success(_categories.value)
                             }
-                            // *** Aquí fuerza también el UI State ***
-                            _uiState.value = CategoryUiState.Success(_categories.value)
                         }
                     }
                 }
-            } catch (e: IOException) {
-                e.printStackTrace()
-                _error.value = "No internet connection"
+                is ApiResult.Error -> {
+                    _uiState.value = CategoryUiState.Error(result.type, result.message)
+                }
+
+                is ApiResult.Empty -> {
+                    _uiState.value = CategoryUiState.Success(emptyList())
+                }
+
+                is ApiResult.NetworkError -> {
+                    _uiState.value = CategoryUiState.Error(
+                        ApiErrorType.NETWORK,
+                        "No internet connection"
+                    )
+                }
             }
-            _loading.value = false
         }
     }
 }

--- a/data/src/main/java/com/jhonprieto/data/repositryImpl/CategoryRepositoryImpl.kt
+++ b/data/src/main/java/com/jhonprieto/data/repositryImpl/CategoryRepositoryImpl.kt
@@ -2,16 +2,38 @@ package com.jhonprieto.data.repositryImpl
 
 import com.jhonprieto.data.mapper.toDomain
 import com.jhonprieto.data.remote.ApiService
+import com.jhonprieto.data.remote.error.ApiErrorHandler
+import com.jhonprieto.data.remote.error.toErrorType
+import com.jhonprieto.domain.ApiResult
 import com.jhonprieto.domain.model.Category
 import com.jhonprieto.domain.model.CategoryDetail
 import com.jhonprieto.domain.repository.CategoryRepository
+import com.jhonprieto.logger.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class CategoryRepositoryImpl(
     private val apiService: ApiService
 ) : CategoryRepository {
     private var categoriesCache: List<Category>? = null
 
-    override suspend fun getCategories(): List<Category> {
+    override suspend fun getCategories(): ApiResult<List<Category>> = withContext(Dispatchers.IO) {
+        runCatching { apiService.getCategories() }
+            .map { it.map { it.toDomain() } }
+            .fold(
+                onSuccess = { categories ->
+                    categoriesCache = categories
+                    if (categories.isEmpty()) ApiResult.Empty else ApiResult.Success(categories)
+                },
+                onFailure = { throwable ->
+                    val apiEx = ApiErrorHandler.parse(throwable)
+                    Logger.e("CategoryRepositoryImpl", "Error in getCategories", apiEx)
+                    ApiResult.Error(apiEx.toErrorType(), apiEx.message ?: apiEx.type.name)
+                }
+            )
+    }
+
+    /*override suspend fun getCategories(): List<Category> {
         categoriesCache?.let {
             return it
         }
@@ -19,7 +41,7 @@ class CategoryRepositoryImpl(
         val result = dtoList.map { it.toDomain() }
         categoriesCache = result
         return result
-    }
+    }*/
 
     override suspend fun getCategoryDetail(categoryId: String): CategoryDetail {
         val dto = apiService.getCategoryDetail(categoryId)

--- a/data/src/main/java/com/jhonprieto/data/repositryImpl/ProductRepositoryImpl.kt
+++ b/data/src/main/java/com/jhonprieto/data/repositryImpl/ProductRepositoryImpl.kt
@@ -3,7 +3,6 @@ package com.jhonprieto.data.repositryImpl
 import com.jhonprieto.data.mapper.toDomain
 import com.jhonprieto.data.remote.ApiService
 import com.jhonprieto.data.remote.error.ApiErrorHandler
-import com.jhonprieto.data.remote.error.ApiException
 import com.jhonprieto.data.remote.error.toErrorType
 import com.jhonprieto.domain.ApiResult
 import com.jhonprieto.domain.model.Product
@@ -44,10 +43,7 @@ class ProductRepositoryImpl(
                 onFailure = { throwable ->
                     val apiEx = ApiErrorHandler.parse(throwable)
                     Logger.e("ProductRepositoryImpl", "Error in getProductDetail", apiEx)
-                    when (apiEx) {
-                        is ApiException.Network -> ApiResult.NetworkError
-                        else -> ApiResult.Error(apiEx.toErrorType(), apiEx.message.orEmpty())
-                    }
+                    ApiResult.Error(apiEx.toErrorType(), apiEx.message ?: apiEx.type.name)
                 }
             )
     }

--- a/domain/src/main/java/com/jhonprieto/domain/repository/CategoryRepository.kt
+++ b/domain/src/main/java/com/jhonprieto/domain/repository/CategoryRepository.kt
@@ -1,9 +1,10 @@
 package com.jhonprieto.domain.repository
 
+import com.jhonprieto.domain.ApiResult
 import com.jhonprieto.domain.model.Category
 import com.jhonprieto.domain.model.CategoryDetail
 
 interface CategoryRepository {
-    suspend fun getCategories(): List<Category>
+    suspend fun getCategories(): ApiResult<List<Category>>
     suspend fun getCategoryDetail(categoryId: String): CategoryDetail
 }

--- a/domain/src/main/java/com/jhonprieto/domain/usecases/CategoriesUseCase.kt
+++ b/domain/src/main/java/com/jhonprieto/domain/usecases/CategoriesUseCase.kt
@@ -3,11 +3,12 @@ package com.jhonprieto.domain.usecases
 import com.jhonprieto.domain.model.Category
 import com.jhonprieto.domain.model.CategoryDetail
 import com.jhonprieto.domain.repository.CategoryRepository
+import com.jhonprieto.domain.repository.ProductRepository
 
 class GetCategoriesUseCase(
     private val repository: CategoryRepository
 ) {
-    suspend operator fun invoke(): List<Category> = repository.getCategories()
+    suspend operator fun invoke() = repository.getCategories()
 }
 
 class GetCategoryDetailUseCase(


### PR DESCRIPTION

Refactored the getCategories method in CategoryRepositoryImpl to align with the error-handling pattern used in searchByQuery.

- Utilized runCatching + fold to consistently map success and failure scenarios.
- Integrated ApiErrorHandler to parse exceptions into ApiErrorType.
- Logged detailed errors for easier debugging and traceability.
- Cached the retrieved category list when successful.

This change ensures consistent domain-layer error handling and enables the UI layer to reuse components like searchErrorView for category-related errors.