### PR TITLE
fix(viewmodel): update UI with cached category images

### DIFF
--- a/app/src/main/java/com/jhonprieto/melifinder/ui/screens/category/CategoryViewModel.kt
+++ b/app/src/main/java/com/jhonprieto/melifinder/ui/screens/category/CategoryViewModel.kt
@@ -9,7 +9,6 @@ import com.jhonprieto.domain.usecases.GetCategoriesUseCase
 import com.jhonprieto.domain.usecases.GetCategoryDetailUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 sealed class CategoryUiState {
@@ -23,7 +22,7 @@ class CategoryViewModel(
     private val getCategoryDetailUseCase: GetCategoryDetailUseCase
 ) : ViewModel() {
 
-    private val _categories = MutableStateFlow<List<Category>>(emptyList())
+    // private val _categories = MutableStateFlow<List<Category>>(emptyList())
     private val _uiState = MutableStateFlow<CategoryUiState>(CategoryUiState.Loading)
     val uiState: StateFlow<CategoryUiState> = _uiState
 
@@ -47,13 +46,16 @@ class CategoryViewModel(
                             launch {
                                 val detail = getCategoryDetailUseCase(category.id)
                                 pictureCache[category.id] = detail.pictureUrl
-                                _categories.update { list ->
-                                    list.map {
-                                        if (it.id == category.id) it.copy(picture = detail.pictureUrl) else it
-                                    }
-                                }
-                                // *** Aquí fuerza también el UI State ***
-                                _uiState.value = CategoryUiState.Success(_categories.value)
+                                val updated = (uiState.value as? CategoryUiState.Success)
+                                    ?.categories
+                                    ?.map {
+                                        if (it.id == category.id) {
+                                            it.copy(picture = detail.pictureUrl)
+                                        } else {
+                                            it
+                                        }
+                                    } ?: emptyList()
+                                _uiState.value = CategoryUiState.Success(updated)
                             }
                         }
                     }

--- a/app/src/main/java/com/jhonprieto/melifinder/ui/screens/category/CategoryViewModel.kt
+++ b/app/src/main/java/com/jhonprieto/melifinder/ui/screens/category/CategoryViewModel.kt
@@ -57,6 +57,17 @@ class CategoryViewModel(
                                     } ?: emptyList()
                                 _uiState.value = CategoryUiState.Success(updated)
                             }
+                        } else {
+                            val updated = (uiState.value as? CategoryUiState.Success)
+                                ?.categories
+                                ?.map {
+                                    if (it.id == category.id) {
+                                        it.copy(picture = pictureCache[category.id])
+                                    } else {
+                                        it
+                                    }
+                                } ?: emptyList()
+                            _uiState.value = CategoryUiState.Success(updated)
                         }
                     }
                 }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         minSdk = 23
 
-        buildConfigField("String", "MELI_BEARER_TOKEN", "\"Bearer APP_USR-4219600329393108-072321-81deeab1ef923dd10422dd4084a0c602-271208496\"")
+        buildConfigField("String", "MELI_BEARER_TOKEN", "\"Bearer APP_USR-4219600329393108-072413-6920dfec2914b8b838992ac4d7316950-271208496\"")
         buildConfigField("String", "MELI_BASE_URL", "\"https://api.mercadolibre.com/\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Added missing else branch in CategoryViewModel to handle cases where the picture for a category is already available in cache.

- Ensures the UI state is updated even when using cached data.
- Fixes issue where picture URLs present in pictureCache were not being reflected in the UI.
- Improves user experience by avoiding unnecessary API calls and enabling faster UI updates.

This change guarantees consistent behavior between fresh API data and cached data, aligning with expected UI rendering.